### PR TITLE
Add Hash Functionality.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ args="--opt:size --app:console --panics:on --mm:orc --backend:c --embedsrc:off -
 if [$1 -eq ""]
 then
     echo "no argument provided, defaulting to nimble build."
-    nimble build
+    platform="linux"
 else
     platform=$1
 fi

--- a/passwordgen.nimble
+++ b/passwordgen.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version       = "1.2.1"
+version       = "1.3.1"
 author        = "RubyKyo"
 description   = "Password Generator. Has options to enable special characters, and to only generate a string with only digits, and etc. You can also change the length."
 license       = "MIT"
@@ -9,4 +9,4 @@ bin           = @["passwordgen"]
 
 
 # Dependencies
-requires "nim >= 1.6.12","cligen == 1.6.2","nimcrypto == 0.5.4"
+requires "nim >= 1.6.12","cligen == 1.6.2","checksums == 0.1.0"

--- a/src/passwordgen.nim
+++ b/src/passwordgen.nim
@@ -1,5 +1,6 @@
 import std/[sysrand,strutils];
 import cligen;
+import checksums/sha3;
 proc sample(strin:string):char = # Gets a random byte from system's entropy pool and tries to get an integer.
   var ch=' ';
   #while ((ints<0) or (ints>strin.len())):
@@ -30,6 +31,7 @@ proc passwordgen(
   lowercase_only:bool=false,
   special_characters:bool=false,
   alphabetic_only:bool=false,
+  hash_res:bool=false
   ) =
   ##A Password Generator, Username Generator, and PIN Generator. You make it how you want to. It is always recommended that you enable multi-factor authentication for whatever service, application, website you are using this program for.
   ##
@@ -70,6 +72,9 @@ proc passwordgen(
     while result.len()<=length:
       result.add(sample(digit_alph))
   # handle the result.
+  if hash_res:
+    result = $Sha3_256.secureHash(result) # char '$' returns the string representation of the Sha3Digest returned from secureHash.
+
   echo result; # print to stdout(terminal/console).
   return;
 
@@ -79,4 +84,5 @@ dispatch passwordgen,help={
   "lowercase_only":"Makes the output all lowercase, if possible.",
   "special_characters":"Add special characters into the output. This is a flag and not set by default because some services may not allow specific special characters.",
   "alphabetic_only":"Makes the output only alphabetic, no special characters.",
+  "hash_res":"Algorithm: Sha3_256. Hashes the result, resulting in a more complicated, un-guessable output. Could be used for something else."
   }


### PR DESCRIPTION
``Warning: target type is larger than source type
  target type: 'BiggestUInt' (8 bytes)
  source type: 'uint32' (4 bytes) [CastSizes]`` 
  Warning given upon compilation by the compiler, overall should be fine to ignore.
  I tested it, and it should work. Tested on Linux.